### PR TITLE
Fix database clearing bug

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -626,11 +626,11 @@ async function clearAllDatabases(): Promise<void> {
   }
   console.log('Presentations database cleared')
 
-  // Clear presentations
-  for (const { key } of presentationDb.getRange()) {
-    await presentationDb.remove(key)
+  // Clear setlists
+  for (const { key } of setlistDb.getRange()) {
+    await setlistDb.remove(key)
   }
-  console.log('Presentations database cleared')
+  console.log('Setlists database cleared')
 
   // Clear slides
   for (const { key } of slideDb.getRange()) {


### PR DESCRIPTION
## Summary
- fix duplicate presentation clearing logic
- clear setlists when wiping local databases

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find eslint config package)*

------
https://chatgpt.com/codex/tasks/task_e_6856c41688548323ab1718d2c9b8ae1c